### PR TITLE
Bringing Dockerfile to main and a change to string convention for a network address 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY Makefile ./
 RUN cd /app
 RUN go mod init go.service.com/v1/api
 RUN go mod tidy
+
 RUN make build
 
 CMD ["./bin/fact"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /app
 EXPOSE 3000
 
 RUN apk add --no-cache bash git make musl-dev
-#RUN go mod init go.service.com/v1/api
-#RUN go mod tidy
 
 # COPY go.mod ./
 COPY *.go ./
@@ -16,6 +14,6 @@ COPY Makefile ./
 RUN cd /app
 RUN go mod init go.service.com/v1/api
 RUN go mod tidy
-RUN make run
+RUN make build
 
 CMD ["./bin/fact"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM golang:1.19-alpine
+
+WORKDIR /app
+EXPOSE 3000
+
+RUN apk add --no-cache bash git make musl-dev
+#RUN go mod init go.service.com/v1/api
+#RUN go mod tidy
+
+# COPY go.mod ./
+COPY *.go ./
+COPY Makefile ./
+# COPY go.sum ./
+# RUN go mod download
+
+RUN cd /app
+RUN go mod init go.service.com/v1/api
+RUN go mod tidy
+RUN make run
+
+CMD ["./bin/fact"]

--- a/main.go
+++ b/main.go
@@ -9,5 +9,5 @@ func main() {
 	svc = NewLoggingService(svc)
 
     apiServer := NewApiServer(svc)
-	log.Fatal(apiServer.Start(":3000"))	
+	log.Fatal(apiServer.Start("0.0.0.0:3000"))
 }


### PR DESCRIPTION
-  Changed make command ran inside Dockerfile to make build 
-  When net/http was used to create a socket to serve on, the convention was working but rather implicit. The string parameter fed to the method which initiates a web server was changed to be more explicit.